### PR TITLE
T17: CLI unifiée (Typer) - pefc pack build|verify|manifest|sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,15 +545,23 @@ all-new: hardening-v011 grove-complete
 validate-summary:
 	$(PY) -c "import json,sys; from pefc.metrics.validator import validate_summary_doc; from pathlib import Path; d=json.load(open('dist/summary.json')); validate_summary_doc(d, Path('schema/summary.schema.json'))" && echo "✅ Summary validation passed"
 
-# T05: Configuration
+# T17: CLI unifiée (Typer)
 export PEFC_CONFIG ?= config/pack.yaml
+export PIPELINE ?= config/pipelines/bench_pack.yaml
 
-public-bench-pack-config:
-	$(PY) scripts/build_public_bench_pack.py --config $(PEFC_CONFIG)
+.PHONY: public-bench-pack verify-pack pack-manifest pack-sign
 
 public-bench-pack:
-	$(PY) scripts/build_public_bench_pack.py --config $(PEFC_CONFIG) --allow-partial || test $$? -eq 10
-	@echo "Pack build completed (success or partial)"
+	pefc --config $(PEFC_CONFIG) pack build --pipeline $(PIPELINE)
 
 public-bench-pack-strict:
-	$(PY) scripts/build_public_bench_pack.py --config $(PEFC_CONFIG)
+	pefc --config $(PEFC_CONFIG) pack build --pipeline $(PIPELINE) --strict
+
+verify-pack:
+	pefc pack verify --zip dist/*.zip --strict
+
+pack-manifest:
+	pefc pack manifest --zip dist/*.zip --print
+
+pack-sign:
+	pefc pack sign --in dist/*.zip --provider cosign

--- a/README.md
+++ b/README.md
@@ -37,12 +37,34 @@ discovery-engine-2cat/
 
 ### Utilisation
 
+#### CLI unifiée (T17)
+
+```bash
+# Pack operations
+pefc pack build --pipeline config/pipelines/bench_pack.yaml
+pefc pack verify --zip dist/*.zip --strict
+pefc pack manifest --zip dist/*.zip --print
+pefc pack sign --in dist/*.zip --provider cosign
+
+# Configuration
+pefc --config config/pack.yaml --json-logs pack build
+pefc version
+```
+
+#### Makefile (compatible)
+
 ```bash
 # Tests
 make ae-test          # Test AE Next-Closure
 make egraph-test      # Test E-graph canonicalization
 make bandit-test      # Test bandit/DPP selection
 make ci-test          # Test CI components
+
+# Pack operations (utilise pefc CLI)
+make public-bench-pack # Build pack avec pipeline par défaut
+make verify-pack      # Vérifier pack avec signature
+make pack-manifest    # Afficher manifest
+make pack-sign        # Signer pack
 
 # Démo
 make discovery-demo   # Démo complète

--- a/pefc/__init__.py
+++ b/pefc/__init__.py
@@ -1,1 +1,2 @@
 # PEFC - Proof Engine for Code
+__version__ = "0.1.0"

--- a/pefc/pack/__init__.py
+++ b/pefc/pack/__init__.py
@@ -1,1 +1,13 @@
-# Package for pack building utilities
+"""
+PEFC Pack module - Pack operations and verification.
+"""
+
+from .verify import verify_zip, print_manifest
+from .signing import sign_with_cosign, sign_with_sha256
+
+__all__ = [
+    "verify_zip",
+    "print_manifest",
+    "sign_with_cosign",
+    "sign_with_sha256",
+]

--- a/pefc/pack/signing.py
+++ b/pefc/pack/signing.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Pack signing utilities with cosign and other providers.
+"""
+from __future__ import annotations
+from pathlib import Path
+import subprocess
+from typing import Optional
+
+
+def sign_with_cosign(artifact: Path, key_ref: Optional[str] = None) -> Path:
+    """
+    Sign an artifact using cosign.
+
+    Args:
+        artifact: Path to the artifact to sign
+        key_ref: Optional key reference for signing
+
+    Returns:
+        Path to the signature file
+
+    Raises:
+        Exception: If signing fails
+    """
+    artifact_path = Path(artifact)
+    sig_path = artifact_path.with_suffix(artifact_path.suffix + ".sig")
+
+    # Build cosign command
+    cmd = ["cosign", "sign-blob"]
+
+    if key_ref:
+        cmd.extend(["--key", key_ref])
+
+    cmd.append(str(artifact_path))
+
+    # Execute cosign command
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    # Write signature to file
+    if result.stdout.strip():
+        sig_path.write_text(result.stdout.strip())
+
+    return sig_path
+
+
+def sign_with_sha256(artifact: Path) -> Path:
+    """
+    Create a SHA256 signature for an artifact.
+
+    Args:
+        artifact: Path to the artifact to sign
+
+    Returns:
+        Path to the signature file
+    """
+    import hashlib
+
+    artifact_path = Path(artifact)
+    sig_path = artifact_path.with_suffix(artifact_path.suffix + ".sha256")
+
+    # Compute SHA256
+    sha256_hash = hashlib.sha256()
+    with open(artifact_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(chunk)
+
+    # Write signature file
+    sig_content = f"{sha256_hash.hexdigest()}  {artifact_path.name}\n"
+    sig_path.write_text(sig_content)
+
+    return sig_path

--- a/pefc/pack/verify.py
+++ b/pefc/pack/verify.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Pack verification utilities for manifest, merkle, and signature validation.
+"""
+from __future__ import annotations
+from zipfile import ZipFile
+from pathlib import Path
+import json
+import hashlib
+import subprocess
+import shlex
+
+
+def _sha256_stream(fobj, chunk=1 << 20):
+    """Compute SHA256 of a file-like object in streaming fashion."""
+    h = hashlib.sha256()
+    while True:
+        b = fobj.read(chunk)
+        if not b:
+            break
+        h.update(b)
+    return h.hexdigest()
+
+
+def _compute_root_from_manifest(manifest: dict) -> str:
+    """Compute Merkle root from manifest files."""
+    g = hashlib.sha256()
+    for e in sorted(manifest["files"], key=lambda x: x["path"]):
+        g.update((e["path"] + "\n").encode())
+        g.update((e["sha256"] + "\n").encode())
+        g.update((str(e["size"]) + "\n").encode())
+    return g.hexdigest()
+
+
+def verify_zip(
+    zip_path: Path,
+    sig_path: Path | None = None,
+    key_ref: str | None = None,
+    strict: bool = True,
+) -> tuple[bool, dict]:
+    """
+    Verify a pack artifact ZIP file.
+
+    Args:
+        zip_path: Path to the ZIP file to verify
+        sig_path: Optional path to signature file
+        key_ref: Optional key reference for cosign verification
+        strict: Whether to fail on any verification error
+
+    Returns:
+        Tuple of (success, report_dict)
+    """
+    report = {"zip": str(zip_path), "checks": {}}
+
+    with ZipFile(zip_path, "r") as z:
+        names = set(z.namelist())
+
+        # Check for manifest.json
+        if "manifest.json" not in names:
+            report["checks"]["manifest"] = "missing"
+            return (False if strict else True, report)
+
+        # Load and validate manifest
+        manifest = json.loads(z.read("manifest.json").decode("utf-8"))
+
+        # Verify files in manifest
+        ok_files = True
+        for e in manifest.get("files", []):
+            if e["path"] not in names:
+                ok_files = False
+                break
+            with z.open(e["path"], "r") as f:
+                h = _sha256_stream(f)
+            ok_files &= h == e["sha256"]
+
+        report["checks"]["files"] = ok_files
+
+        # Verify Merkle root
+        root = _compute_root_from_manifest(manifest)
+        report["checks"]["merkle_root_match_manifest"] = root == manifest.get(
+            "merkle_root"
+        )
+
+        # Check merkle.txt if present
+        if "merkle.txt" in names:
+            merkle_txt = z.read("merkle.txt").decode("utf-8").strip()
+            report["checks"]["merkle_txt_match"] = root == merkle_txt
+
+        # Overall verification result
+        ok = all(report["checks"].get(k, True) for k in report["checks"])
+
+    # Verify signature if provided
+    if sig_path and sig_path.exists():
+        try:
+            cmd = f"cosign verify-blob --signature {shlex.quote(str(sig_path))}"
+            if key_ref:
+                cmd += f" --key {shlex.quote(key_ref)}"
+            cmd += f" {shlex.quote(str(zip_path))}"
+
+            subprocess.run(cmd, shell=True, check=True, capture_output=True)
+            report["checks"]["signature"] = True
+        except Exception as e:
+            report["checks"]["signature"] = False
+            report["signature_error"] = str(e)
+            ok = False if strict else ok
+
+    return (ok, report)
+
+
+def print_manifest(zip_path: Path) -> dict:
+    """
+    Extract and return manifest from a pack artifact.
+
+    Args:
+        zip_path: Path to the ZIP file
+
+    Returns:
+        Manifest dictionary
+    """
+    with ZipFile(zip_path, "r") as z:
+        if "manifest.json" not in z.namelist():
+            raise ValueError("No manifest.json found in pack")
+
+        manifest_data = z.read("manifest.json")
+        return json.loads(manifest_data.decode("utf-8"))

--- a/proofengine/core/llm_client.py
+++ b/proofengine/core/llm_client.py
@@ -141,9 +141,17 @@ class LLMClient:
             choices = data.get("choices", [])
             if len(choices) > 1:
                 # Return the first choice for now, but we'll implement voting
-                return choices[0]["message"]["content"], data.get("usage", {}), latency_ms
+                return (
+                    choices[0]["message"]["content"],
+                    data.get("usage", {}),
+                    latency_ms,
+                )
 
-        return data["choices"][0]["message"]["content"], data.get("usage", {}), latency_ms
+        return (
+            data["choices"][0]["message"]["content"],
+            data.get("usage", {}),
+            latency_ms,
+        )
 
     def generate(self, request: LLMRequest) -> LLMResponse:
         """Generate response with auto-consistency and caching."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,113 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pefc"
+version = "0.1.0"
+description = "Proof Engine for Code - Unified CLI and pack operations"
+authors = [
+    {name = "Discovery Engine Team", email = "team@discovery-engine.org"}
+]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "openai>=1.43.0",
+    "tenacity>=8.4.2",
+    "pydantic>=2.7.0",
+    "python-dotenv>=1.0.1",
+    "typer>=0.12.3",
+    "rich>=13.7.1",
+    "pytest>=7.0.0",
+    "flake8>=6.0.0",
+    "mypy>=1.0.0",
+    "bandit>=1.7.0",
+    "radon>=6.0.0",
+]
+
+[project.scripts]
+pefc = "pefc.cli:app"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "flake8>=6.0.0",
+    "mypy>=1.0.0",
+    "bandit>=1.7.0",
+    "radon>=6.0.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pefc*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "--verbose",
+    "--tb=short",
+]
+
+[tool.black]
+line-length = 88
+target-version = ['py310']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+[tool.bandit]
+exclude_dirs = ["tests", "test_*"]
+skips = ["B101", "B601"]

--- a/scripts/test_strategies_expected_fail.py
+++ b/scripts/test_strategies_expected_fail.py
@@ -4,17 +4,16 @@ Validates that strategies work correctly in red/green scenarios.
 """
 
 import json
-import os
 import sys
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any
 
 # Add the project root to the Python path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 # Import after path setup
-from proofengine.strategies import (
+from proofengine.strategies import (  # noqa: E402
     SpecializeThenRetryStrategy,
     AddMissingTestsStrategy,
     RequireSemverStrategy,
@@ -22,7 +21,7 @@ from proofengine.strategies import (
     DecomposeMeetStrategy,
     RetryWithHardeningStrategy,
 )
-from proofengine.orchestrator.strategy_api import StrategyContext
+from proofengine.orchestrator.strategy_api import StrategyContext  # noqa: E402
 
 
 class StrategyExpectedFailTester:

--- a/tests/test_cli_pack.py
+++ b/tests/test_cli_pack.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Tests for PEFC CLI pack operations.
+"""
+import json
+import zipfile
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+from pefc.cli import app
+
+
+class TestPackBuild:
+    """Test pack build command."""
+
+    def test_pack_build_smoke(self, tmp_path, monkeypatch):
+        """Test pack build with minimal setup."""
+        # Mock all dependencies
+        monkeypatch.setattr(
+            "pefc.pipeline.core.PipelineRunner.execute", lambda self, steps: 0
+        )
+        monkeypatch.setattr("pefc.pipeline.loader.load_pipeline", lambda path: [])
+        monkeypatch.setattr("pefc.config.loader.load_config", lambda path=None: Mock())
+        monkeypatch.setattr("pefc.logging.init_logging", lambda **kwargs: None)
+        monkeypatch.setattr("pefc.events.get_event_bus", lambda: Mock())
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["pack", "build"])
+
+        # Should succeed with mocked dependencies
+        assert result.exit_code == 0
+
+    def test_pack_build_with_strict(self, tmp_path, monkeypatch):
+        """Test pack build with strict mode."""
+        # Mock PipelineRunner.execute to return success
+        monkeypatch.setattr(
+            "pefc.pipeline.core.PipelineRunner.execute", lambda self, steps: 0
+        )
+
+        # Mock load_pipeline
+        monkeypatch.setattr("pefc.pipeline.loader.load_pipeline", lambda path: [])
+
+        # Mock load_config
+        mock_config = Mock()
+        mock_config.pack.out_dir = str(tmp_path)
+        monkeypatch.setattr(
+            "pefc.config.loader.load_config", lambda path=None: mock_config
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["pack", "build", "--strict"])
+
+        assert result.exit_code == 0
+
+
+class TestPackVerify:
+    """Test pack verify command."""
+
+    def test_pack_verify_manifest_merkle(self, tmp_path):
+        """Test pack verify with manifest and merkle validation."""
+        # Create a test ZIP with manifest and merkle
+        zpath = tmp_path / "test.zip"
+
+        # Create test files
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test content")
+
+        # Compute SHA256 of test file
+        import hashlib
+
+        sha256_hash = hashlib.sha256(test_file.read_bytes()).hexdigest()
+
+        # Create manifest
+        files = [
+            {
+                "path": "test.txt",
+                "size": len(test_file.read_bytes()),
+                "sha256": sha256_hash,
+            }
+        ]
+
+        # Compute Merkle root
+        g = hashlib.sha256()
+        g.update(b"test.txt\n")
+        g.update(sha256_hash.encode() + b"\n")
+        g.update(str(len(test_file.read_bytes())).encode() + b"\n")
+        merkle_root = g.hexdigest()
+
+        manifest = {"version": "v0.1.0", "files": files, "merkle_root": merkle_root}
+
+        # Create ZIP
+        with zipfile.ZipFile(zpath, "w") as z:
+            z.writestr("test.txt", test_file.read_bytes())
+            z.writestr("manifest.json", json.dumps(manifest))
+            z.writestr("merkle.txt", merkle_root + "\n")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["pack", "verify", "--zip", str(zpath), "--strict"])
+
+        assert result.exit_code == 0
+
+        # Parse output JSON
+        output = json.loads(result.stdout)
+        assert output["checks"]["files"] is True
+        assert output["checks"]["merkle_root_match_manifest"] is True
+        assert output["checks"]["merkle_txt_match"] is True
+
+    def test_pack_verify_missing_manifest(self, tmp_path):
+        """Test pack verify with missing manifest."""
+        zpath = tmp_path / "test.zip"
+
+        # Create ZIP without manifest
+        with zipfile.ZipFile(zpath, "w") as z:
+            z.writestr("test.txt", b"content")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["pack", "verify", "--zip", str(zpath), "--strict"])
+
+        assert result.exit_code == 1
+
+        # Parse output JSON
+        output = json.loads(result.stdout)
+        assert output["checks"]["manifest"] == "missing"
+
+
+class TestPackManifest:
+    """Test pack manifest command."""
+
+    def test_pack_manifest_print(self, tmp_path):
+        """Test pack manifest print."""
+        zpath = tmp_path / "test.zip"
+
+        # Create test manifest
+        manifest = {
+            "version": "v0.1.0",
+            "files": [{"path": "test.txt", "size": 0, "sha256": "abc123"}],
+            "merkle_root": "def456",
+        }
+
+        # Create ZIP
+        with zipfile.ZipFile(zpath, "w") as z:
+            z.writestr("manifest.json", json.dumps(manifest))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "manifest", "--zip", str(zpath), "--print"]
+        )
+
+        assert result.exit_code == 0
+
+        # Parse output JSON
+        output = json.loads(result.stdout)
+        assert output["version"] == "v0.1.0"
+        assert output["merkle_root"] == "def456"
+
+    def test_pack_manifest_save_to_file(self, tmp_path):
+        """Test pack manifest save to file."""
+        zpath = tmp_path / "test.zip"
+        out_path = tmp_path / "manifest.json"
+
+        # Create test manifest
+        manifest = {
+            "version": "v0.1.0",
+            "files": [{"path": "test.txt", "size": 0, "sha256": "abc123"}],
+            "merkle_root": "def456",
+        }
+
+        # Create ZIP
+        with zipfile.ZipFile(zpath, "w") as z:
+            z.writestr("manifest.json", json.dumps(manifest))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "manifest", "--zip", str(zpath), "--out", str(out_path)]
+        )
+
+        assert result.exit_code == 0
+        assert out_path.exists()
+
+        # Verify saved manifest
+        saved_manifest = json.loads(out_path.read_text())
+        assert saved_manifest["version"] == "v0.1.0"
+
+
+class TestPackSign:
+    """Test pack sign command."""
+
+    def test_pack_sign_cosign(self, tmp_path, monkeypatch):
+        """Test pack sign with cosign."""
+        artifact_path = tmp_path / "test.zip"
+        artifact_path.write_bytes(b"test content")
+
+        # Mock cosign command
+        mock_sig_path = tmp_path / "test.zip.sig"
+        mock_sig_path.write_text("mock signature")
+
+        def mock_sign_with_cosign(artifact, key_ref=None):
+            return mock_sig_path
+
+        monkeypatch.setattr("pefc.pack.signing.sign_with_cosign", mock_sign_with_cosign)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "sign", "--in", str(artifact_path), "--provider", "cosign"]
+        )
+
+        assert result.exit_code == 0
+        assert str(mock_sig_path) in result.stdout
+
+    def test_pack_sign_unknown_provider(self, tmp_path):
+        """Test pack sign with unknown provider."""
+        artifact_path = tmp_path / "test.zip"
+        artifact_path.write_bytes(b"test content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "sign", "--in", str(artifact_path), "--provider", "unknown"]
+        )
+
+        assert result.exit_code == 2
+        assert "Unknown provider" in result.stdout
+
+
+class TestVersion:
+    """Test version command."""
+
+    def test_version_command(self):
+        """Test version command."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+        # Should print version (exact format depends on __version__)
+        assert result.stdout.strip() is not None

--- a/tests/test_cli_simple.py
+++ b/tests/test_cli_simple.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Tests simples pour PEFC CLI.
+"""
+from typer.testing import CliRunner
+
+from pefc.cli import app
+
+
+class TestCLIBasic:
+    """Test CLI basique."""
+
+    def test_version_command(self):
+        """Test version command."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+        assert "0.1.0" in result.stdout
+
+    def test_help_command(self):
+        """Test help command."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "PEFC CLI" in result.stdout
+
+    def test_pack_help(self):
+        """Test pack help."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["pack", "--help"])
+
+        assert result.exit_code == 0
+        assert "Pack operations" in result.stdout


### PR DESCRIPTION
- Implémentation CLI unifiée avec Typer
- Sous-commandes pack: build, verify, manifest, sign
- Intégration logging JSON et EventBus
- Configuration centralisée avec --config
- Vérification manifest/merkle/signature
- Signature avec cosign et sha256
- Tests CLI avec CliRunner
- Makefile adapté pour utiliser pefc
- pyproject.toml avec console_scripts
- README mis à jour avec exemples CLI

Fixes: T17