### PR TITLE
T18: Artefacts traçables - manifest JSON dans l'archive

### DIFF
--- a/pefc/pack/verify.py
+++ b/pefc/pack/verify.py
@@ -9,6 +9,7 @@ import json
 import hashlib
 import subprocess
 import shlex
+import fastjsonschema
 
 
 def _sha256_stream(fobj, chunk=1 << 20):
@@ -39,7 +40,7 @@ def verify_zip(
     strict: bool = True,
 ) -> tuple[bool, dict]:
     """
-    Verify a pack artifact ZIP file.
+    Verify a pack artifact ZIP file with comprehensive validation.
 
     Args:
         zip_path: Path to the ZIP file to verify
@@ -50,44 +51,38 @@ def verify_zip(
     Returns:
         Tuple of (success, report_dict)
     """
-    report = {"zip": str(zip_path), "checks": {}}
+    report = {"zip": str(zip_path), "checks": {}, "errors": []}
+    overall_success = True
 
-    with ZipFile(zip_path, "r") as z:
-        names = set(z.namelist())
-
-        # Check for manifest.json
-        if "manifest.json" not in names:
-            report["checks"]["manifest"] = "missing"
-            return (False if strict else True, report)
-
+    try:
         # Load and validate manifest
-        manifest = json.loads(z.read("manifest.json").decode("utf-8"))
+        manifest = load_manifest(zip_path)
+        report["checks"]["manifest_valid"] = True
 
-        # Verify files in manifest
-        ok_files = True
-        for e in manifest.get("files", []):
-            if e["path"] not in names:
-                ok_files = False
-                break
-            with z.open(e["path"], "r") as f:
-                h = _sha256_stream(f)
-            ok_files &= h == e["sha256"]
-
-        report["checks"]["files"] = ok_files
+        # Verify files SHA256
+        files_ok, files_report = verify_files_sha256(zip_path, manifest)
+        report["checks"]["files_sha256"] = files_ok
+        report["files_report"] = files_report
+        if not files_ok:
+            report["errors"].extend(files_report.get("errors", []))
+            overall_success = False
 
         # Verify Merkle root
-        root = _compute_root_from_manifest(manifest)
-        report["checks"]["merkle_root_match_manifest"] = root == manifest.get(
-            "merkle_root"
-        )
+        merkle_ok, merkle_report = verify_merkle(zip_path, manifest)
+        report["checks"]["merkle_root"] = merkle_ok
+        report["merkle_report"] = merkle_report
+        if not merkle_ok:
+            report["errors"].extend(merkle_report.get("errors", []))
+            overall_success = False
 
-        # Check merkle.txt if present
-        if "merkle.txt" in names:
-            merkle_txt = z.read("merkle.txt").decode("utf-8").strip()
-            report["checks"]["merkle_txt_match"] = root == merkle_txt
-
-        # Overall verification result
-        ok = all(report["checks"].get(k, True) for k in report["checks"])
+    except ValueError as e:
+        report["checks"]["manifest_valid"] = False
+        report["errors"].append(f"Manifest error: {e}")
+        overall_success = False
+    except Exception as e:
+        report["checks"]["manifest_valid"] = False
+        report["errors"].append(f"Unexpected error: {e}")
+        overall_success = False
 
     # Verify signature if provided
     if sig_path and sig_path.exists():
@@ -102,9 +97,155 @@ def verify_zip(
         except Exception as e:
             report["checks"]["signature"] = False
             report["signature_error"] = str(e)
-            ok = False if strict else ok
+            report["errors"].append(f"Signature verification failed: {e}")
+            overall_success = False
 
-    return (ok, report)
+    # Final result
+    if strict and not overall_success:
+        return (False, report)
+    else:
+        return (overall_success, report)
+
+
+def load_manifest(zip_path: Path) -> dict:
+    """
+    Load and validate manifest from a pack artifact.
+
+    Args:
+        zip_path: Path to the ZIP file
+
+    Returns:
+        Manifest dictionary
+
+    Raises:
+        ValueError: If manifest is missing or invalid
+    """
+    with ZipFile(zip_path, "r") as z:
+        if "manifest.json" not in z.namelist():
+            raise ValueError("No manifest.json found in pack")
+
+        manifest_data = z.read("manifest.json")
+        manifest = json.loads(manifest_data.decode("utf-8"))
+
+        # Validate against schema
+        try:
+            schema_path = (
+                Path(__file__).parent.parent.parent / "schema" / "manifest.schema.json"
+            )
+            with open(schema_path, "r") as f:
+                schema = json.load(f)
+            fastjsonschema.validate(schema, manifest)
+        except Exception as e:
+            raise ValueError(f"Manifest validation failed: {e}")
+
+        return manifest
+
+
+def verify_files_sha256(zip_path: Path, manifest: dict) -> tuple[bool, dict]:
+    """
+    Verify SHA256 hashes of all files in the manifest.
+
+    Args:
+        zip_path: Path to the ZIP file
+        manifest: Manifest dictionary
+
+    Returns:
+        Tuple of (success, report_dict)
+    """
+    report = {
+        "files_verified": 0,
+        "files_total": len(manifest.get("files", [])),
+        "errors": [],
+    }
+
+    with ZipFile(zip_path, "r") as z:
+        for file_info in manifest.get("files", []):
+            path = file_info["path"]
+            expected_sha256 = file_info["sha256"]
+
+            if path not in z.namelist():
+                report["errors"].append(f"File not found in ZIP: {path}")
+                continue
+
+            try:
+                with z.open(path, "r") as f:
+                    actual_sha256 = _sha256_stream(f)
+
+                if actual_sha256 == expected_sha256:
+                    report["files_verified"] += 1
+                else:
+                    report["errors"].append(
+                        f"SHA256 mismatch for {path}: expected {expected_sha256}, got {actual_sha256}"
+                    )
+            except Exception as e:
+                report["errors"].append(f"Error reading {path}: {e}")
+
+    success = (
+        len(report["errors"]) == 0 and report["files_verified"] == report["files_total"]
+    )
+    return success, report
+
+
+def verify_merkle(zip_path: Path, manifest: dict) -> tuple[bool, dict]:
+    """
+    Verify Merkle root calculation.
+
+    Args:
+        zip_path: Path to the ZIP file
+        manifest: Manifest dictionary
+
+    Returns:
+        Tuple of (success, report_dict)
+    """
+    report = {"merkle_verified": False, "errors": []}
+
+    try:
+        # Recalculate Merkle root from manifest files
+        from pefc.pack.merkle import compute_merkle_root, PackEntry
+
+        # Create PackEntry objects from manifest
+        entries = []
+        for file_info in manifest.get("files", []):
+            # Skip manifest.json and merkle.txt from Merkle calculation
+            if file_info["path"] in {"manifest.json", "merkle.txt"}:
+                continue
+
+            entry = PackEntry(
+                arcname=file_info["path"],
+                src_path=Path("dummy"),  # Not used for calculation
+                size=file_info["size"],
+                sha256=file_info["sha256"],
+                leaf=file_info["leaf"],
+            )
+            entries.append(entry)
+
+        # Calculate Merkle root
+        calculated_root = compute_merkle_root(entries)
+        expected_root = manifest.get("merkle_root")
+
+        if calculated_root == expected_root:
+            report["merkle_verified"] = True
+        else:
+            report["errors"].append(
+                f"Merkle root mismatch: expected {expected_root}, got {calculated_root}"
+            )
+
+        # Also verify merkle.txt if present
+        with ZipFile(zip_path, "r") as z:
+            if "merkle.txt" in z.namelist():
+                merkle_txt = z.read("merkle.txt").decode("utf-8").strip()
+                if merkle_txt != expected_root:
+                    report["errors"].append(
+                        f"merkle.txt mismatch: expected {expected_root}, got {merkle_txt}"
+                    )
+                else:
+                    report["merkle_txt_verified"] = True
+
+    except Exception as e:
+        report["errors"].append(f"Error calculating Merkle root: {e}")
+
+    success = len(report["errors"]) == 0 and report["merkle_verified"]
+    return success, report
 
 
 def print_manifest(zip_path: Path) -> dict:
@@ -117,9 +258,4 @@ def print_manifest(zip_path: Path) -> dict:
     Returns:
         Manifest dictionary
     """
-    with ZipFile(zip_path, "r") as z:
-        if "manifest.json" not in z.namelist():
-            raise ValueError("No manifest.json found in pack")
-
-        manifest_data = z.read("manifest.json")
-        return json.loads(manifest_data.decode("utf-8"))
+    return load_manifest(zip_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "typer>=0.12.3",
     "rich>=13.7.1",
+    "fastjsonschema>=2.18.0",
     "pytest>=7.0.0",
     "flake8>=6.0.0",
     "mypy>=1.0.0",

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Pack Manifest Schema",
+  "description": "Schema for pack manifest.json files",
+  "type": "object",
+  "required": [
+    "format_version",
+    "pack_name",
+    "version",
+    "built_at",
+    "builder",
+    "file_count",
+    "total_size_bytes",
+    "merkle_root",
+    "files"
+  ],
+  "properties": {
+    "format_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Manifest format version"
+    },
+    "pack_name": {
+      "type": "string",
+      "description": "Name of the pack"
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the pack"
+    },
+    "built_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC ISO8601 timestamp when pack was built"
+    },
+    "builder": {
+      "type": "object",
+      "required": ["cli_version", "host"],
+      "properties": {
+        "cli_version": {
+          "type": "string",
+          "description": "Version of the CLI used to build"
+        },
+        "host": {
+          "type": "string",
+          "description": "Hostname of the build machine"
+        }
+      },
+      "additionalProperties": false
+    },
+    "file_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of files in the pack"
+    },
+    "total_size_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total size of payload files (excluding manifest.json and merkle.txt)"
+    },
+    "merkle_root": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Hex digest of Merkle root (64 hex chars)"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "size", "sha256", "leaf"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "POSIX path within the pack"
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "File size in bytes"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$",
+            "description": "SHA256 hex digest of file content"
+          },
+          "leaf": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$",
+            "description": "Merkle leaf hash"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "signature": {
+      "type": "object",
+      "required": ["present"],
+      "properties": {
+        "present": {
+          "type": "boolean",
+          "description": "Whether signature is present"
+        },
+        "provider": {
+          "type": "string",
+          "enum": ["cosign", "sha256"],
+          "description": "Signature provider"
+        },
+        "signature_path": {
+          "type": "string",
+          "description": "Path to signature file"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Tests for manifest validation and verification.
+"""
+import json
+import zipfile
+
+from typer.testing import CliRunner
+
+from pefc.cli import app
+from pefc.pack.merkle import build_entries, compute_merkle_root, build_manifest
+from pefc.pack.verify import (
+    verify_zip,
+)
+
+
+class TestManifestValidation:
+    """Test manifest validation functionality."""
+
+    def test_build_manifest_complete(self, tmp_path):
+        """Test building complete manifest with all fields."""
+        # Create test files
+        test_file1 = tmp_path / "test1.txt"
+        test_file1.write_text("content1")
+
+        test_file2 = tmp_path / "test2.txt"
+        test_file2.write_text("content2")
+
+        # Build entries
+        entries = build_entries([(test_file1, "test1.txt"), (test_file2, "test2.txt")])
+
+        # Compute Merkle root
+        merkle_root = compute_merkle_root(entries)
+
+        # Build manifest
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="test-pack",
+            version="1.0.0",
+            cli_version="0.1.0",
+        )
+
+        # Verify manifest structure
+        assert manifest["format_version"] == "1.0"
+        assert manifest["pack_name"] == "test-pack"
+        assert manifest["version"] == "1.0.0"
+        assert manifest["merkle_root"] == merkle_root
+        assert manifest["file_count"] == 2
+        assert manifest["total_size_bytes"] == len("content1") + len("content2")
+        assert "builder" in manifest
+        assert manifest["builder"]["cli_version"] == "0.1.0"
+        assert "host" in manifest["builder"]
+        assert len(manifest["files"]) == 2
+
+        # Verify file entries
+        for file_info in manifest["files"]:
+            assert "path" in file_info
+            assert "size" in file_info
+            assert "sha256" in file_info
+            assert "leaf" in file_info
+
+    def test_manifest_with_signature_info(self, tmp_path):
+        """Test manifest with signature information."""
+        # Create test file
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        # Build entries
+        entries = build_entries([(test_file, "test.txt")])
+        merkle_root = compute_merkle_root(entries)
+
+        # Build manifest with signature info
+        signature_info = {
+            "present": True,
+            "provider": "cosign",
+            "signature_path": "test.txt.sig",
+        }
+
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="signed-pack",
+            version="1.0.0",
+            signature_info=signature_info,
+        )
+
+        assert manifest["signature"] == signature_info
+
+    def test_verify_zip_with_manifest(self, tmp_path):
+        """Test verifying a ZIP with proper manifest."""
+        # Create test files
+        test_file1 = tmp_path / "file1.txt"
+        test_file1.write_text("content1")
+
+        test_file2 = tmp_path / "file2.txt"
+        test_file2.write_text("content2")
+
+        # Build entries
+        entries = build_entries([(test_file1, "file1.txt"), (test_file2, "file2.txt")])
+
+        merkle_root = compute_merkle_root(entries)
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="test-pack",
+            version="1.0.0",
+        )
+
+        # Create ZIP with manifest
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as z:
+            # Add payload files
+            z.writestr("file1.txt", test_file1.read_bytes())
+            z.writestr("file2.txt", test_file2.read_bytes())
+            # Add manifest and merkle
+            z.writestr("manifest.json", json.dumps(manifest, indent=2))
+            z.writestr("merkle.txt", merkle_root + "\n")
+
+        # Verify the ZIP
+        success, report = verify_zip(zip_path, strict=True)
+
+        assert success
+        assert report["checks"]["manifest_valid"] is True
+        assert report["checks"]["files_sha256"] is True
+        assert report["checks"]["merkle_root"] is True
+        assert len(report["errors"]) == 0
+
+    def test_verify_zip_missing_manifest(self, tmp_path):
+        """Test verifying ZIP without manifest."""
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as z:
+            z.writestr("file.txt", b"content")
+
+        success, report = verify_zip(zip_path, strict=True)
+
+        assert not success
+        assert report["checks"]["manifest_valid"] is False
+        assert len(report["errors"]) > 0
+
+    def test_verify_zip_corrupted_file(self, tmp_path):
+        """Test verifying ZIP with corrupted file."""
+        # Create test files
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("original content")
+
+        # Build entries
+        entries = build_entries([(test_file, "file.txt")])
+        merkle_root = compute_merkle_root(entries)
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="test-pack",
+            version="1.0.0",
+        )
+
+        # Create ZIP with corrupted file
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as z:
+            # Add corrupted file (different content)
+            z.writestr("file.txt", b"corrupted content")
+            z.writestr("manifest.json", json.dumps(manifest, indent=2))
+            z.writestr("merkle.txt", merkle_root + "\n")
+
+        # Verify should fail
+        success, report = verify_zip(zip_path, strict=True)
+
+        assert not success
+        assert report["checks"]["files_sha256"] is False
+        assert len(report["errors"]) > 0
+
+    def test_cli_verify_command(self, tmp_path):
+        """Test CLI verify command with manifest."""
+        # Create test files
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+
+        # Build entries and manifest
+        entries = build_entries([(test_file, "file.txt")])
+        merkle_root = compute_merkle_root(entries)
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="test-pack",
+            version="1.0.0",
+        )
+
+        # Create ZIP
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as z:
+            z.writestr("file.txt", test_file.read_bytes())
+            z.writestr("manifest.json", json.dumps(manifest, indent=2))
+            z.writestr("merkle.txt", merkle_root + "\n")
+
+        # Test CLI verify
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "verify", "--zip", str(zip_path), "--strict"]
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["checks"]["manifest_valid"] is True
+
+    def test_cli_manifest_command(self, tmp_path):
+        """Test CLI manifest command."""
+        # Create test files
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+
+        # Build entries and manifest
+        entries = build_entries([(test_file, "file.txt")])
+        merkle_root = compute_merkle_root(entries)
+        manifest = build_manifest(
+            entries=entries,
+            merkle_root=merkle_root,
+            pack_name="test-pack",
+            version="1.0.0",
+        )
+
+        # Create ZIP
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as z:
+            z.writestr("file.txt", test_file.read_bytes())
+            z.writestr("manifest.json", json.dumps(manifest, indent=2))
+            z.writestr("merkle.txt", merkle_root + "\n")
+
+        # Test CLI manifest
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pack", "manifest", "--zip", str(zip_path), "--print"]
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["format_version"] == "1.0"
+        assert output["pack_name"] == "test-pack"
+        assert output["merkle_root"] == merkle_root


### PR DESCRIPTION
- Schéma JSON complet pour manifest v1.0
- Extension build_manifest() avec tous les champs requis
- Vérification complète: SHA256, Merkle, validation schéma
- Fonctions verify_files_sha256() et verify_merkle()
- Tests complets pour validation manifest
- Intégration CLI pefc pack verify/manifest
- Dépendance fastjsonschema ajoutée

Fixes: T18